### PR TITLE
Fix Issue #39: Update deployment_target for cocoa pods

### DIFF
--- a/Block-KVO.podspec
+++ b/Block-KVO.podspec
@@ -9,4 +9,5 @@ Pod::Spec.new do |s|
   s.source_files = "Sources", "Sources/**/*"
   s.public_header_files = "MTKObserving.h"
   s.requires_arc = true
+  s.ios.deployment_target = '5.0'
 end


### PR DESCRIPTION
Issue #39: Update deployment_target for cocoa pods

Deployment target should be explicitly set to 5.0 or over when building with new cocoa pods.

Thanks for your work,
Cheers g4bor