### PR TITLE
Update documentation for macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The above code example using provided macro:
 
 ```objc
 MTKObservePropertySelf(profile.username, NSString *, {
-    self.usernameLabel.text = newUsername;
+    self.usernameLabel.text = new;
 });
 ```
 


### PR DESCRIPTION
The macro's block argument is 'old' and 'new'. 

Thanks for the great library!