### PR TITLE
Observed dealloc crash fix

### DIFF
--- a/Sources/NSObject+MTKObserving.m
+++ b/Sources/NSObject+MTKObserving.m
@@ -71,10 +71,15 @@
         observer = [[MTKObserver alloc] initWithTarget:self keyPath:keyPath owner:owner];
         [observersForKeyPath addObject:observer];
         [observer attach];
-        
-        [owner mtk_addDeallocationCallback:^(id owner) {
-            [observer.target mtk_removeObservationsForOwner:owner keyPath:keyPath];
-        }];
+		
+		if (owner!=self) {
+			// If not observing self, register a dealloc task to detach the observer if the owner is destroyed first.
+			// A weak reference makes the block safe to execute if the observer is destroyed first.
+			__weak MTKObserver* weakObserver = observer;
+			[owner mtk_addDeallocationCallback:^(id owner) {
+				[weakObserver.target mtk_removeObservationsForOwner:owner keyPath:keyPath];
+			}];
+			}
     }
     return observer;
 }

--- a/Sources/NSObject+MTKObserving.m
+++ b/Sources/NSObject+MTKObserving.m
@@ -34,13 +34,13 @@
         if ( ! keyPathObservers) {
             keyPathObservers = [[NSMutableDictionary alloc] init];
             objc_setAssociatedObject(self, _cmd, keyPathObservers, OBJC_ASSOCIATION_RETAIN);
+			// On initial setup, register a block to remove all observations during dealloc
+			[self mtk_addDeallocationCallback:^(id self) {
+				[self internalRemoveAllObservations];
+			}];
         }
-        
-        [self mtk_addDeallocationCallback:^(id self) {
-            [self internalRemoveAllObservations];
-        }];
-        
-        return keyPathObservers;
+
+		return keyPathObservers;
     }
 }
 


### PR DESCRIPTION
Found a bug that would cause a crash if the observed object / observer object were destroyed before its owner object. While debugging, I also found a couple of memory leaks / pointless code.

1. If an owner object creates an observer for another object, and that observed object is deallocated first, the program will crash when the observer is deallocated. The problem is that the owner retains the observer and tries to remove it from the (now nonexistent) target object. The fix is to modify the closure so it retains a weak reference to the observer. Now, if the observed object is destroyed first, it will destroy all of its observers and the owner will now have nil references and do nothing.

2. When the associated observer dictionary is first attached to an object, a block of code (`[self internalRemoveAllObservations]`) is registered with the dealloc-swizzle to remove all observers before the object is destroyed. However, it was outside of the "first time" code path, causing another reference to this housekeeping block to be added to the dealloc task list *every* time the observer dictionary was requested. The code has been relocated so this only happens once.

3. A second on-dealloc block of code is registered by the owner to detach and remove each individual observer when the owner is deallocated. A block is registered for every observed key-path. However, this is completely redundant when the owner is observing itself; the owner will first perform `-internalRemoveAllObservations` (see 2), removing *all* observers. Any subsequent block of code that removes a specific observer will do nothing, as they have already been removed. The new code registers this block iff the owner is not observing itself.

4. Updated the unit tests and added a unit test to confirm the fix for 1.